### PR TITLE
Add error catching for read_sift

### DIFF
--- a/R/read_many_sift.R
+++ b/R/read_many_sift.R
@@ -18,7 +18,11 @@
 
 read_many_sift <- function(files, table = "concentrations", ...) {
   read_specific <- function(file, table = table) {
-    all_sift <- siftr::read_sift(file = file, chatty = FALSE, ...)
+    all_sift <- siftr::read_sift(file = file, chatty = FALSE, warn = TRUE, ...)
+
+    if(is.null(all_sift)){
+      return(NULL)
+    }
 
     single_table <- all_sift[[table]] %>%
       dplyr::mutate(start_time = all_sift$time) %>%

--- a/R/read_many_sift2.R
+++ b/R/read_many_sift2.R
@@ -14,7 +14,11 @@
 
 read_many_sift2 <- function(files, ...) {
   read_sift_tbl <- function(file) {
-    sift_data <- siftr::read_sift(file, ...)
+    sift_data <- siftr::read_sift(file, warn = TRUE, ...)
+
+    if(is.null(sift_data)){
+      return(NULL)
+    }
 
     lst_to_df <- function(n) {
       name <- names(sift_data)[n]


### PR DESCRIPTION
Each table in read_sift is now wrapped in a tryCatch - this is so that the use of `read_many_sift()` can be improved.

If the new `warn` argument is set to TRUE, the first table to fail to be read will produce a warning, and the function will return NULL. If it is FALSE (the default for `read_sift()`, an error will be thrown instead.  `read_many_sift()` and `read_many_sift2()` set `warn = TRUE` so a bad file will not disrupt the reading of a whole folder. They have been adjusted to handle NULLs while binding the data.