### PR TITLE
fixed bug in read_proc_sift

### DIFF
--- a/R/read_proc_sift.R
+++ b/R/read_proc_sift.R
@@ -17,7 +17,7 @@ read_proc_sift <- function(file) {
   # Calculate start and end lines for each section
   start_ends <- lines %>%
     dplyr::filter(stringr::str_detect(line, ".xml")) %>%
-    dplyr::mutate(end = dplyr::lead(start)) %>%
+    dplyr::mutate(end = dplyr::lead(start)-2) %>%
     tidyr::replace_na(list(end = max(lines$start)))
 
   # Subfunction: Read in each bit of the data individually by mapping over our starts and ends


### PR DESCRIPTION
Previously the function read the first line from the following table. Caused type problems during pivoting. Fixed by setting the end line of a table to be set two lines before the start of the following table