### PR TITLE
Replaced the read_proc_sift function (which was malfunctioning)

### DIFF
--- a/R/read_proc_sift.R
+++ b/R/read_proc_sift.R
@@ -1,90 +1,103 @@
 #' Read Processed SIFT Data
 #'
 #' @description This is a function to read data that has already been processed
-#'   by the SYFT into three tables - analyte concentrations, concentrations per
-#'   reagent and concentrations per product.
+#'   by LabSyft (into up to six different tables - Analyte concentrations,
+#'   Analyte concentrations per reagent ion, Analyte concentrations per product
+#'   ion, and their raw equivalents) into a single data frame. Each .csv file
+#'   can contain multiple times. Use lapply() and bind_rows() to read multiple
+#'   sheets at once.
 #'
-#' @param file The file path for the pre-processed SIFT .csv file.
+#' @param file_path A character string specifying the path to the Processed SIFT .csv file.
 #'
-#' @return A list.
+#' @return A data frame with columns: table, time_s, compound_identity, conc.
 #' @export
 #'
 
-read_proc_sift <- function(file) {
-  lines <- tibble::tibble(line = readLines(file)) %>%
-    dplyr::mutate(start = dplyr::row_number())
+read_proc_sift <- function(file_path) {
+  # Read the entire CSV file
+  raw_data <- readLines(file_path)
 
-  # Calculate start and end lines for each section
-  start_ends <- lines %>%
-    dplyr::filter(stringr::str_detect(line, ".xml")) %>%
-    dplyr::mutate(end = dplyr::lead(start)-2) %>%
-    tidyr::replace_na(list(end = max(lines$start)))
-
-  # Subfunction: Read in each bit of the data individually by mapping over our starts and ends
-  read_data <- function(start, end) {
-    title <- suppressWarnings(readr::read_csv(
-      file = file, col_types = readr::cols(),
-      skip = start - 1, n_max = 1, col_names = F
-    )) %>%
-      dplyr::pull(1) %>%
-      gsub("\\..*", "", .) %>%
-      janitor::make_clean_names()
-
-    df <- suppressWarnings(readr::read_csv(file,
-      col_types = readr::cols(),
-      skip = start, n_max = end - start,
-      locale = readr::locale(encoding = "ISO-8859-1")
-    )) %>%
-      dplyr::mutate(
-        table = title,
-        start_time = stringr::word(table, start = -2, end = -1, sep = "_") %>% lubridate::ymd_hms(),
-        table = stringr::word(table, start = 1, end = -3, sep = "_")
-      ) %>%
-      dplyr::relocate(table, start_time) %>%
-      tidyr::pivot_longer(-(1:3), values_to = "conc") %>%
-      dplyr::mutate(name = stringr::str_replace_all(name, "\\(R\\)", "R")) %>%
-      dplyr::mutate(name = stringr::str_replace_all(name, "\\(S\\)", "S")) %>%
-      janitor::clean_names() %>%
-      dplyr::mutate(time_s = as.numeric(time_s)) |>
-      tidyr::drop_na()
-
-    return(df)
-  }
-
-  # Map using the above function - returns a list.
-  raw <- purrr::map2(.x = start_ends$start, .y = start_ends$end, .f = ~ read_data(start = .x, end = .y))
-
-  all_indices <- seq(length(raw))
-  index_remainders <- all_indices %% 3
-  analyte_indices <- all_indices[index_remainders == 1]
-  reagent_indices <- all_indices[index_remainders == 2]
-  product_indices <- all_indices[index_remainders == 0]
-
-  analyte_conc <- raw[analyte_indices] %>%
-    dplyr::bind_rows() |>
-    tidyr::separate(name, into = c("compound", "CAS_number", "unit"), sep = " \\(") %>%
-    dplyr::mutate(dplyr::across(where(is.character), stringr::str_remove, "\\)"),
-      unit = stringr::str_replace_all(unit, "\U00B3", "3")
-    )
-
-  conc_per_reagent <- raw[reagent_indices] %>%
-    dplyr::bind_rows() |>
-    tidyr::separate(name, into = c("reagent_ion", "compound", "CAS_number", "unit"), sep = " \\(| / ") %>%
-    dplyr::mutate(dplyr::across(where(is.character), stringr::str_remove, "\\)"))
-
-  conc_per_product <- raw[product_indices] %>%
-    dplyr::bind_rows() |>
-    tidyr::separate(name,
-      into = c("product_ion", "product_ion_mass", "reagent_ion", "compound", "CAS_number", "unit"),
-      sep = " \\[|  / | / | \\("
-    ) %>%
-    dplyr::mutate(dplyr::across(where(is.character), stringr::str_remove, "\\)|\\]"))
-
-  sift <- list(
-    analyte_conc = analyte_conc,
-    conc_per_reagent = conc_per_reagent,
-    conc_per_product = conc_per_product
+  # Initialize an empty data frame to store the final result
+  result_df <- data.frame(
+    table = character(),
+    time_s = numeric(),
+    compound_identity = character(),
+    conc = numeric(),
+    stringsAsFactors = FALSE
   )
 
-  return(sift)
+  # Loop through the lines and find headers
+  i <- 1
+  while (i <= length(raw_data)) {
+    line <- raw_data[i]
+
+    # Check if the line contains ".xml" which indicates the start of a new table
+    if (grepl(".xml", line)) {
+      table <- line  # Capture the entire .xml line as the table name
+
+      # Ensure there is a line for column names
+      if ((i + 1) > length(raw_data)) {
+        warning(paste("No column names found after .xml header at line", i))
+        break
+      }
+
+      # Use read.csv to correctly parse column names, which may contain commas
+      colnames_line <- read.csv(text = raw_data[i + 1], header = FALSE, stringsAsFactors = FALSE)
+      colnames_line <- unlist(colnames_line)
+
+      # Find the index of "Time (s)"
+      time_col_idx <- which(trimws(colnames_line) == "Time (s)")
+
+      if (length(time_col_idx) == 0) {
+        warning(paste('"Time (s)" column not found after .xml header at line', i))
+        break
+      }
+
+      # Extract the table data (assuming data follows the column names)
+      data_start <- i + 2
+      j <- data_start
+
+      while (j <= length(raw_data) && !grepl(".xml", raw_data[j])) {
+        j <- j + 1
+      }
+
+      table_data <- read.csv(
+        text = paste(raw_data[data_start:(j-1)], collapse = "\n"),
+        header = FALSE, stringsAsFactors = FALSE
+      )
+
+      # Remove trailing empty rows if present
+      table_data <- table_data[complete.cases(table_data[, time_col_idx]), ]
+
+      # Loop through each column (except the Time (s) column)
+      for (col_idx in (time_col_idx + 1):ncol(table_data)) {
+        # Ensure that the concentration column has the same length as the time column
+        conc_values <- as.numeric(table_data[[col_idx]])
+        conc_values <- ifelse(is.na(conc_values), NA, conc_values)
+
+        # Construct the data frame for the current compound
+        temp_df <- data.frame(
+          table = rep(table, length(conc_values)),
+          time_s = as.numeric(table_data[[time_col_idx]]),
+          compound_identity = rep(colnames_line[col_idx], length(conc_values)),
+          conc = conc_values,
+          stringsAsFactors = FALSE
+        )
+
+        # Explicitly set row names to NULL to avoid warnings
+        rownames(temp_df) <- NULL
+
+        # Bind this to the result dataframe
+        result_df <- rbind(result_df, temp_df)
+      }
+
+      # Move to the next table
+      i <- j
+    } else {
+      # Just move to the next line
+      i <- i + 1
+    }
+  }
+
+  return(result_df)
 }

--- a/man/read_proc_sift.Rd
+++ b/man/read_proc_sift.Rd
@@ -4,16 +4,19 @@
 \alias{read_proc_sift}
 \title{Read Processed SIFT Data}
 \usage{
-read_proc_sift(file)
+read_proc_sift(file_path)
 }
 \arguments{
-\item{file}{The file path for the pre-processed SIFT .csv file.}
+\item{file_path}{A character string specifying the path to the Processed SIFT .csv file.}
 }
 \value{
-A list.
+A data frame with columns: table, time_s, compound_identity, conc.
 }
 \description{
 This is a function to read data that has already been processed
-by the SYFT into three tables - analyte concentrations, concentrations per
-reagent and concentrations per product.
+by LabSyft (into up to six different tables - Analyte concentrations,
+Analyte concentrations per reagent ion, Analyte concentrations per product
+ion, and their raw equivalents) into a single data frame. Each .csv file
+can contain multiple times. Use lapply() and bind_rows() to read multiple
+sheets at once.
 }


### PR DESCRIPTION
This function reads a processed SIFT .csv file (which contains multiple tables such as analyte conc, conc per reagent, conc per product and their raw equiavlents) over mutliple start times to create a single data frame with four columns: table, time_s, compound_identity and conc. Subsequent functions will be produced to filter and expand the columns of these tables.