### PR TITLE
Update read_proc_sift.R

### DIFF
--- a/R/read_proc_sift.R
+++ b/R/read_proc_sift.R
@@ -15,7 +15,8 @@
 
 read_proc_sift <- function(file_path) {
   # Read the entire CSV file
-  raw_data <- readLines(file_path)
+  raw_data <- readLines(file_path, encoding = "latin1")
+  raw_data <- iconv(raw_data, from = "latin1", to = "UTF-8")
 
   # Initialize an empty data frame to store the final result
   result_df <- data.frame(


### PR DESCRIPTION
Adds conversion from latin1 character formatting to UTF-8 to enable function to read in processed SIFT-MS data from LabSyft with concentration units of mg/m3, ug/m3 or ng/m3 (in addition to ppm, ppb or ppt)